### PR TITLE
Fix node version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": ""
   },
   "engines": {
-    "node": "~v0.4.9"
+    "node": "~0.4.9"
   },
   "dependencies": {
     "nko": "~0.1.0",


### PR DESCRIPTION
npm gives the following error when that `v` is in the node version number of package.json

```
npm WARN Invalid range in engines.node.  Please see `npm help json` ~v0.4.9
```
