### PR TITLE
Use dive instead of findit to prevent issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "express": "~2.4.6",
     "commander": "~0.1.0",
-    "findit": "~0.1.1",
+    "dive": ">=0.1.0",
     "socket.io": "~0.7.9",
     "node-uuid": "~1.2.0"
   },


### PR DESCRIPTION
There is an issue in [findit](https://github.com/substack/node-findit)/[seq](https://github.com/substack/node-seq) that causes nide to crash when loading a big project:
- https://github.com/substack/node-findit/issues/2
- https://github.com/substack/node-seq/issues/17

[massimiliano-giroldi](https://github.com/massimiliano-giroldi) asked me, if [dive](https://github.com/pvorb/node-dive) could do the job. I looked at the code of seq and assumed the error got something to do with the chaining of seq.

So I patched nide. Now
- it uses [dive](https://github.com/pvorb/node-dive)
- it's faster
- [issue](https://github.com/substack/node-seq/issues/17) does not occur anymore

Feel free to test it.
