### PR TITLE
Fix problem in version history

### DIFF
--- a/server/project.js
+++ b/server/project.js
@@ -31,7 +31,7 @@ setInterval(function() {
                 date: (new Date()).valueOf(),
                 uuid: generatedUuid
             })
-            exec('cp -- ' + (process.cwd() + file) + ' ' + (process.cwd() + '/.nide/' + generatedUuid), function(err) {
+            exec('cp -- "' + (process.cwd() + file) + '" "' + (process.cwd() + '/.nide/' + generatedUuid) + '"', function(err) {
                 if (!err) {
                     saveVersionHistory()
                 }


### PR DESCRIPTION
Add quotes to copy function for version history to allow for spaces in paths.
