### PR TITLE
Version History

### DIFF
--- a/client/js/CodeEditor.js
+++ b/client/js/CodeEditor.js
@@ -114,8 +114,10 @@
         var loadVersionNumbered = function(i) {
             if (!versions[i].content) {
                 connection.loadVersion(versions[i].uuid, function(err, contents) {
+                    galaxyBackground.revert.disabled = false;
                     if (err) {
-                        contents = '<ERROR: Could not load file contents>'
+                        contents = '<ERROR: Could not load file contents>';
+                        galaxyBackground.revert.disabled = true;
                     }
                     var codeMirror = createCodeMirror(versionEditors[i], contents, entry.path, { readOnly: true })
                     versions[i].content = contents;

--- a/server/project.js
+++ b/server/project.js
@@ -31,7 +31,7 @@ setInterval(function() {
                 date: (new Date()).valueOf(),
                 uuid: generatedUuid
             })
-            exec('cp -- "' + (process.cwd() + file) + '" "' + (process.cwd() + '/.nide/' + generatedUuid) + '"', function(err) {
+            exec('cp -- "' + (process.cwd() + file).replace(/[\\"']/g, '\\$&').replace(/\u0000/g, '\\0') + '" "' + (process.cwd() + '/.nide/' + generatedUuid).replace(/[\\"']/g, '\\$&').replace(/\u0000/g, '\\0') + '"', function(err) {
                 if (!err) {
                     saveVersionHistory()
                 }


### PR DESCRIPTION
Addon to my previous fix for file paths. Properly escapes strings to allow for usage of quotes within file path.

UPDATE: And disable reverting to older version if file cannot be opened.
