### PR TITLE
Fixed directory structure being sent before being fully built on opening a project

### DIFF
--- a/server/project.js
+++ b/server/project.js
@@ -149,8 +149,11 @@ exports.list = function(noCache) {
             path: "",
             children: {}
         }
+        var encountered = 0, added = 0;
         dive(process.cwd(), { recursive: true, all: true, directories: true },
         function(err, path) {
+            encountered++;
+
             if (err) {
                 console.warn(err);
                 return
@@ -167,9 +170,11 @@ exports.list = function(noCache) {
                 } else {
                     addToListCache(path + "/.")
                 }
+
+                if (++added == encountered) {
+                    ee.emit('success', listCache);
+                }
             })
-        }, function() {
-            ee.emit('success', listCache)
         })
     } else {
         process.nextTick(function() {


### PR DESCRIPTION
Kudos for the great work on this project, I'm really impressed. However, there was one little issue that cropped up after I decided to add another structural level to my project, which looked something like so:

./package.json
./responses/file1.json
./responses/file2.json

Simple! The issue was that upon loading the project (by running the 'nide' command in the root directory), the 'responses' directory had been showing as containing no files (i.e. empty). After a bit of debugging it seemed that adding some logging statements to the code responsible for injecting things into the listCache slowed the execution down enough that the files were visible more often than before when repeatedly starting the IDE. Therefore, and after some further investigation, I figured the object was being sent out too quickly -- before it had actually been constructed.

After this change we're now ensuring that the number of processed files equals the number of 'encountered' files before we proceed to dispatch the listCache off to the client. This is serving as an effective fix to the problem I've been able to replicate locally.
