### PR TITLE
Adding initial work to support windows, including switches on the Window...

### DIFF
--- a/main.js
+++ b/main.js
@@ -6,11 +6,14 @@ var project = require('./server/project');
 var exec = require('child_process').exec
 var path = require('path')
 var fs = require('fs')
+var os = require('os');
 
 var packageJSON = JSON.parse(fs.readFileSync(__dirname + '/package.json', 'utf-8'))
 
 var checkForDependencies = function(callback) {
-    exec('which npm', function(err, stdout, stderr) {
+    //Windows does not, by default, have the command which. The equivelant is where, thus, adding here.
+    var execCommand = ( os.type == "Windows NT" ) ? "where npm" : "which npm";
+    exec(execCommand, function(err, stdout, stderr) {
         if (err) {
             console.error('Could not find `npm` command. Is npm installed?')
             process.exit(-1)

--- a/server/server.js
+++ b/server/server.js
@@ -2,6 +2,7 @@ var express = require('express');
 var sockeio = require('socket.io')
 var project = require('./project.js')
 var child_process = require('child_process')
+var os = require( 'os' )
 
 var server = express.createServer();
 var staticServer = express.createServer();
@@ -57,6 +58,8 @@ exports.listen = function(port, host, username, password, downgrade, launchBrows
 
     server.listen(port, host, function() {
         staticServer.listen(port+1, host, function() {
+            //ignore this work for windows Operating Systems
+            if (os.type != "Windows_NT" )
             // if run as root, downgrade to the owner of this file
             if (process.getuid() === 0) {
                 if(downgrade == true){


### PR DESCRIPTION
I've fixed a couple of issues preventing nide from running on Windows. They are:
- The which command is not on windows by default (the equivalent is where)
- Windows doesn't support the node.js concept of uids

With these changes, users can run nide on windows, provided that they are willing to install the missing libraries nide requires manually, as the process will error out initially. 
